### PR TITLE
Updates mobile menu submodule and docs

### DIFF
--- a/docs/mobile-menu-update.md
+++ b/docs/mobile-menu-update.md
@@ -93,4 +93,4 @@ No manual CSS is needed as long as the ACF fields are set. If you need to overri
 | Show search icon | Toggles search button |
 | Show cart icon | Requires WooCommerce |
 | Show account icon | Requires WooCommerce |
-| Show language switcher | Toggles the WPML language switcher icon. This setting only appears in the Customizer when WPML is active. The icon renders only when WPML is active **and** at least 2 languages are configured. |
+| Show language switcher | Requires WPML with at least 2 active languages |


### PR DESCRIPTION
Updates the mobile menu submodule, incorporating the latest changes and improvements from the subproject.

Clarifies the documentation for the mobile menu's language switcher setting, making its display requirements more concise and easier to understand for users.