### PR TITLE
Fix undefined STOCK_STATUS_ON_RESERVE in reserve button fallback

### DIFF
--- a/inc/other-functions.php
+++ b/inc/other-functions.php
@@ -1622,7 +1622,7 @@ if ( ! function_exists('dsn_show_reserve_btn') ) {
     }
 
     // Show reserve button if product is on reserve and has a price.
-    if ($product->get_stock_status() === STOCK_STATUS_ON_RESERVE && $product->is_purchasable())
+    if ($product->get_stock_status() === 'on_reserve' && $product->is_purchasable())
     {
       return true;
     }


### PR DESCRIPTION
## Summary

- Fixes the PHP fatal on shop / archive pages when the Syndified plugin is deactivated.
- `dsn_show_reserve_btn()` fallback at `inc/other-functions.php:1625` referenced `STOCK_STATUS_ON_RESERVE`, which is defined only by the Syndified plugin. Since the fallback runs specifically when Syndified is **not** active, the constant is always undefined on that path → fatal error.
- Replaced the constant with the literal `'on_reserve'` so the fallback stands on its own.

Closes #235
