### PR TITLE
Show Reserve button on variable products with on_reserve variations

### DIFF
--- a/inc/other-functions.php
+++ b/inc/other-functions.php
@@ -1621,10 +1621,18 @@ if ( ! function_exists('dsn_show_reserve_btn') ) {
       return false;
     }
 
-    // Show reserve button if product is on reserve and has a price.
     if ($product->get_stock_status() === 'on_reserve' && $product->is_purchasable())
     {
       return true;
+    }
+
+    if ($product->is_type('variable')) {
+      foreach ($product->get_children() as $variation_id) {
+        $variation = wc_get_product($variation_id);
+        if ($variation && $variation->get_stock_status() === 'on_reserve' && $variation->is_purchasable()) {
+          return true;
+        }
+      }
     }
 
     return false;

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -184,7 +184,7 @@ function dsn_handle_product_action_buttons() {
         if (dsn_show_reserve_btn($product_id)){
             add_action('woocommerce_single_product_summary', 'dsn_reserve_button', $is_variable ? 35 : 10);
             if ($is_variable) {
-                remove_action('woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20);
+                remove_action('woocommerce_after_variations_form', 'woocommerce_single_variation_add_to_cart_button', 20);
             } else {
                 remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30);
             }
@@ -196,7 +196,7 @@ function dsn_handle_product_action_buttons() {
 
         if(!dsn_show_add_to_cart($product_id)){
             if ($is_variable) {
-                remove_action('woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20);
+                remove_action('woocommerce_after_variations_form', 'woocommerce_single_variation_add_to_cart_button', 20);
             } else {
                 remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30);
             }

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -179,10 +179,15 @@ function dsn_handle_product_action_buttons() {
         }
 
         $product_id = $product->get_id();
+        $is_variable = $product->is_type('variable');
 
         if (dsn_show_reserve_btn($product_id)){
-            add_action('woocommerce_single_product_summary', 'dsn_reserve_button');
-            remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30);
+            add_action('woocommerce_single_product_summary', 'dsn_reserve_button', $is_variable ? 35 : 10);
+            if ($is_variable) {
+                remove_action('woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20);
+            } else {
+                remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30);
+            }
         }
 
         if(dsn_show_get_info_btn($product_id)) {
@@ -190,7 +195,11 @@ function dsn_handle_product_action_buttons() {
         }
 
         if(!dsn_show_add_to_cart($product_id)){
-            remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30);
+            if ($is_variable) {
+                remove_action('woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20);
+            } else {
+                remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30);
+            }
         }
     }
 }

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -185,6 +185,7 @@ function dsn_handle_product_action_buttons() {
             add_action('woocommerce_single_product_summary', 'dsn_reserve_button', $is_variable ? 35 : 10);
             if ($is_variable) {
                 remove_action('woocommerce_after_variations_form', 'woocommerce_single_variation_add_to_cart_button', 20);
+                add_action('woocommerce_after_variations_form', 'dsn_render_variation_hidden_inputs_only', 20);
             } else {
                 remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30);
             }
@@ -197,11 +198,25 @@ function dsn_handle_product_action_buttons() {
         if(!dsn_show_add_to_cart($product_id)){
             if ($is_variable) {
                 remove_action('woocommerce_after_variations_form', 'woocommerce_single_variation_add_to_cart_button', 20);
+                add_action('woocommerce_after_variations_form', 'dsn_render_variation_hidden_inputs_only', 20);
             } else {
                 remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30);
             }
         }
     }
+}
+
+function dsn_render_variation_hidden_inputs_only() {
+    global $product;
+    if (!$product) {
+        return;
+    }
+    $product_id = absint($product->get_id());
+    echo '<div class="woocommerce-variation-add-to-cart variations_button dsn-variation-hidden-inputs-only">';
+    echo '<input type="hidden" name="add-to-cart" value="' . $product_id . '" />';
+    echo '<input type="hidden" name="product_id" value="' . $product_id . '" />';
+    echo '<input type="hidden" name="variation_id" class="variation_id" value="0" />';
+    echo '</div>';
 }
 
 add_action('woocommerce_single_product_summary', 'dsn_handle_product_action_buttons', 1);


### PR DESCRIPTION
Closes #238

## Summary
- `dsn_show_reserve_btn()` fallback now walks variations for variable products. If any purchasable variation has `_stock_status = on_reserve`, the helper returns `true`. Previously it only checked the parent's `get_stock_status()`, which WC aggregates to `instock`/`outofstock` for variable products — so the Reserve button never appeared even when every variation was on reserve.
- `dsn_handle_product_action_buttons()` no longer rips out the entire variations form when switching a variable product into Reserve mode. For variable products it removes only the per-variation cart button hook (`woocommerce_single_variation_add_to_cart_button`) and renders the Reserve button after the variations form (priority 35) so the user can still see the variation dropdown.
