### PR TITLE
Strip attribute rows from Additional information tab

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -77,6 +77,11 @@ function woo_rename_tabs($tabs)
             'priority' => 1,
             'callback' => 'woo_new_product_tab_more'
         );
+    } else {
+        global $product;
+        if (!$product || (!$product->has_weight() && !$product->has_dimensions())) {
+            unset($tabs['additional_information']);
+        }
     }
 
     if (get_field('custom_block_content')) {

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -77,8 +77,6 @@ function woo_rename_tabs($tabs)
             'priority' => 1,
             'callback' => 'woo_new_product_tab_more'
         );
-    } else {
-        unset($tabs['additional_information']);
     }
 
     if (get_field('custom_block_content')) {
@@ -92,6 +90,17 @@ function woo_rename_tabs($tabs)
     }
 
     return $tabs;
+}
+
+add_filter('woocommerce_display_product_attributes', 'dsn_strip_attribute_rows_from_additional_information', 99);
+function dsn_strip_attribute_rows_from_additional_information($product_attributes)
+{
+    foreach (array_keys($product_attributes) as $key) {
+        if (strpos($key, 'attribute_') === 0) {
+            unset($product_attributes[$key]);
+        }
+    }
+    return $product_attributes;
 }
 
 function woo_new_product_tab_more()

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -77,6 +77,8 @@ function woo_rename_tabs($tabs)
             'priority' => 1,
             'callback' => 'woo_new_product_tab_more'
         );
+    } else {
+        unset($tabs['additional_information']);
     }
 
     if (get_field('custom_block_content')) {


### PR DESCRIPTION
Closes #240

Filter `woocommerce_display_product_attributes` and remove rows keyed `attribute_*`. Weight, dimensions, and the theme's "More Details" override stay untouched. Variation attributes already appear in the variation dropdown, so the table rows for them were redundant.